### PR TITLE
Add option to specify connection timeout in seconds

### DIFF
--- a/bloodyAD/main.py
+++ b/bloodyAD/main.py
@@ -65,6 +65,11 @@ def main():
         help="IP of the DNS to resolve AD names (useful for inter-domain functions)",
     )
     parser.add_argument(
+        "-t",
+        "--timeout",
+        help="Connction timeout in seconds",
+    )
+    parser.add_argument(
         "--gc",
         help="Connect to Global Catalog (GC)",
         action="store_true",

--- a/bloodyAD/network/config.py
+++ b/bloodyAD/network/config.py
@@ -27,6 +27,7 @@ class Config:
     realmc: str = ""
     krbformat: str = "ccache"
     dns: str = ""
+    timeout: int = 0
 
     def __post_init__(self):
         # Resolve dc ip
@@ -117,6 +118,7 @@ class ConnectionHandler:
                 dcip=args.dc_ip,
                 format=args.format,
                 dns=args.dns,
+                timeout=args.timeout,
             )
         else:
             cnf = config

--- a/bloodyAD/network/ldap.py
+++ b/bloodyAD/network/ldap.py
@@ -142,6 +142,9 @@ class Ldap(MSLDAPClient):
                     if cnf.format in ["b64", "hex"]:
                         auth += cnf.format
 
+        if cnf.timeout:
+            params += "&timeout=" + cnf.timeout
+
         auth = "+" + auth if auth else ""
         creds = username if username else ""
         creds = creds + ":" + key if key else creds


### PR DESCRIPTION
During a recent engagement I ran into a timeout while proxying bloodyAD over a slow SOCKS connection.

This adds a `-t`/`--timeout` option which allows to specify the connection timeout in seconds.