### PR TITLE
Add option to limit lifetime of created users and computers

### DIFF
--- a/bloodyAD/cli_modules/add.py
+++ b/bloodyAD/cli_modules/add.py
@@ -12,13 +12,14 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from bloodyAD.exceptions import BloodyError
 
 
-def computer(conn, hostname: str, newpass: str, ou: str = "DefaultOU"):
+def computer(conn, hostname: str, newpass: str, ou: str = "DefaultOU", lifetime: int = 0):
     """
     Add new computer
 
     :param hostname: computer name (without trailing $)
     :param newpass: password for computer
     :param ou: Organizational Unit for computer
+    :param lifetime: lifetime of new computer in seconds, if non-zero creates it as a dynamic object
     """
 
     if ou == "DefaultOU":
@@ -60,6 +61,10 @@ def computer(conn, hostname: str, newpass: str, ou: str = "DefaultOU"):
         "sAMAccountName": f"{hostname}$",
         "unicodePwd": '"%s"' % newpass,
     }
+
+    if lifetime > 0:
+        attr["objectClass"].append("dynamicObject")
+        attr["entryTTL"] = lifetime
 
     conn.ldap.bloodyadd(computer_dn, attributes=attr)
     LOG.info(f"[+] {hostname} created")

--- a/bloodyAD/cli_modules/add.py
+++ b/bloodyAD/cli_modules/add.py
@@ -411,13 +411,14 @@ def uac(conn, target: str, f: list = None):
     LOG.info(f"[-] {f} property flags added to {target}'s userAccountControl")
 
 
-def user(conn, sAMAccountName: str, newpass: str, ou: str = "DefaultOU"):
+def user(conn, sAMAccountName: str, newpass: str, ou: str = "DefaultOU", lifetime: int = 0):
     """
     Add a new user
 
     :param sAMAccountName: sAMAccountName for new user
     :param newpass: password for new user
     :param ou: Organizational Unit for new user
+    :param lifetime: lifetime of new user in seconds, if non-zero creates it as a dynamic object
     """
     if ou == "DefaultOU":
         container = None
@@ -444,6 +445,10 @@ def user(conn, sAMAccountName: str, newpass: str, ou: str = "DefaultOU"):
         "userAccountControl": 544,
         "unicodePwd": '"%s"' % newpass,
     }
+
+    if lifetime > 0:
+        attr["objectClass"].append("dynamicObject")
+        attr["entryTTL"] = lifetime
 
     conn.ldap.bloodyadd(user_dn, attributes=attr)
     LOG.info(f"[+] {sAMAccountName} created")


### PR DESCRIPTION
[Dynamic objects](https://learn.microsoft.com/en-us/windows/win32/ad/dynamic-objects) have an associated TTL after which they will be deleted without being tombstoned and moved to the AD recycle bin. In certain scenarios this might be desirable behavior. This pull request allows to create new users/computers as dynamic objects by specifying their `--lifetime` in seconds.

Query minimal and default object lifetime of dynamic objects:
```
$ bloodyAD --host 10.5.10.11 -d ludus.domain -u domainadmin -p password get object "CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,DC=ludus,DC=domain" --attr msDS-Other-Settings

distinguishedName: CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,DC=ludus,DC=domain
msDS-Other-Settings: DisableVLVSupport=0; DynamicObjectMinTTL=900; DynamicObjectDefaultTTL=86400
```

Create new user with minimal dynamic object lifetime:
```
$ bloodyAD --host 10.5.10.11 -d ludus.domain -u domainadmin -p password add user dynamicuser password --lifetime 900
[+] dynamicuser created
```

Verify successful creation by querying the decreasing entry time to live with the new user credentials:
```
$ bloodyAD --host 10.5.10.11 -d ludus.domain -u dynamicuser -p password get object dynamicuser --attr entryTTL 

distinguishedName: CN=dynamicuser,CN=Users,DC=ludus,DC=domain
entryTTL: 875
```

Let the TTL expire and repeat query:
```
$ sleep 900 && bloodyAD --host 10.5.10.11 -d ludus.domain -u dynamicuser -p password get object dynamicuser --attr entryTTL
...
msldap.commons.exceptions.LDAPBindException: LDAP Bind failed! Result code: "invalidCredentials" Reason: "b'8009030C: LdapErr: DSID-0C090585, comment: AcceptSecurityContext error, data 52e, v4f7c\x00'"
```

As expected, the user does no longer exist, hence the login fails. Verify with domainadmin too:
```
$ bloodyAD --host 10.5.10.11 -d ludus.domain -u domainadmin -p password get object dynamicuser
...
bloodyAD.exceptions.NoResultError: [-] No object found in DC=ludus,DC=domain with filter: (sAMAccountName=dynamicuser)
```

Similarly, create a new computer object with limited lifetime:
```
$ bloodyAD --host 10.5.10.11 -d ludus.domain -u domainadmin -p password add computer dynamiccomputer password --lifetime 900
[+] dynamiccomputer created
```

Query its TTL using the new credentials:
```
$ bloodyAD --host 10.5.10.11 -d ludus.domain -u 'dynamiccomputer$' -p password get object 'dynamiccomputer$' --attr entryTTL

distinguishedName: CN=dynamiccomputer,CN=Computers,DC=ludus,DC=domain
entryTTL: 775
```

Let the TTL expire and repeat query:
```
$ sleep 900 && bloodyAD --host 10.5.10.11 -d ludus.domain -u 'dynamiccomputer$' -p password get object 'dynamiccomputer$' --attr entryTTL
...
msldap.commons.exceptions.LDAPBindException: LDAP Bind failed! Result code: "invalidCredentials" Reason: "b'8009030C: LdapErr: DSID-0C090585, comment: AcceptSecurityContext error, data 52e, v4f7c\x00'"
```

Same query, but using a regular domain account:
```
$ bloodyAD --host 10.5.10.11 -d ludus.domain -u domainuser -p password get object 'dynamiccomputer$' --attr entryTTL
...
bloodyAD.exceptions.NoResultError: [-] No object found in DC=ludus,DC=domain with filter: (sAMAccountName=dynamiccomputer$)
```