### PR TITLE
Add SPN handling (add/remove)

### DIFF
--- a/bloodyAD/cli_modules/add.py
+++ b/bloodyAD/cli_modules/add.py
@@ -284,6 +284,21 @@ def rbcd(conn, target: str, service: str):
 
     LOG.info(f"[+] {service} can now impersonate users on {target} via S4U2Proxy")
 
+def spn(conn, target: str, service: str):
+    """
+    Add an SPN to a target account (Requires "Write" permission on target's servicePrincipalName)
+
+    :param target: sAMAccountName, DN, GUID or SID of the target
+    :param service: servicePrincipalName to add (for example: http/host.domain.local or cifs/host.domain.local)
+    """
+    target_dn = conn.ldap.dnResolver(target)
+    conn.ldap.bloodymodify(
+        target_dn,
+        {"servicePrincipalName": [(Change.ADD.value, str(service))]},
+    )
+
+    LOG.info(f"[+] servicePrincipalName attribute of {target} updated")
+
 
 def shadowCredentials(conn, target: str, path: str = "CurrentPath"):
     """

--- a/bloodyAD/cli_modules/remove.py
+++ b/bloodyAD/cli_modules/remove.py
@@ -226,6 +226,25 @@ def rbcd(conn, target: str, service: str):
 
     LOG.info(f"[-] {service} can't impersonate users on {target} anymore")
 
+def spn(conn, target: str, service: str):
+    """
+    Remove an SPN from a target account (Requires "Write" permission on target's servicePrincipalName)
+
+    :param target: sAMAccountName, DN, GUID or SID of the target
+    :param service: servicePrincipalName to remove (get object target --attr servicePrincipalName)
+    """
+    target_dn = conn.ldap.dnResolver(target)
+    spns = next(conn.ldap.bloodysearch(target, attr=["servicePrincipalName"]))["servicePrincipalName"]
+    
+    if service not in spns:
+        LOG.warning(f"[!] Target SPN not found on {target}")
+    else:
+        conn.ldap.bloodymodify(
+            target_dn,
+            {"servicePrincipalName": [(Change.DELETE.value, str(service))]},
+        )
+        LOG.info(f"[-] servicePrincipalName {service} removed from {target}")
+
 
 def shadowCredentials(conn, target: str, key: str = None):
     """


### PR DESCRIPTION
Quick addition to the `add` and `remove` modules.

Maybe we can also add an entry to the `get` module ? But it would just be a shortcut to `get object target --attr servicePrincipalName`