### PR TITLE
Include a lowercase variant of the command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,4 @@ dependencies = [
 
 [project.scripts]
 bloodyAD = "bloodyAD.main:main"
+bloodyad = "bloodyAD.main:main"


### PR DESCRIPTION
According to the Command Line Interface Guidelines, the name of the command [should only use lowercase letters](https://clig.dev/#naming). 

> **Use only lowercase letters, and dashes if you really need to**. `curl` is a good name, `DownloadURL` is not.

`bloodyad` has therefore been added to project.scripts. `bloodyAD` has not been removed for
the sake of backwards compatibility.