### PR TITLE
Adding privileged groups filter on resolve-sd and Acl-only Filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 version = "2.5.0"
 description = "AD Privesc Swiss Army Knife"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
# Summary

I’ve always liked using bloodyAD for quick enumeration and made some changes so I can see only the ACLs and even filter the default privilege ones while using `get object`.

# Details

- `get object --resolve-sd --acl-only --filter-admin-default` now post-processes rendered security descriptors and drops ACEs where every trustee is in a curated list of built-in admin groups (Administrators, Domain Admins, Account Operators, etc.). This keeps non-default trustees visible while trimming the noise.

- Added helper logic to normalize trustee names before comparison and documented the behavior inline, so it’s clear this is an optional display filter.

- Bumped requires-python in pyproject.toml to >=3.10 because badldap>=0.7.1 now pulls dnspython>=2.7.0, which no longer supports 3.8/3.9.