### PR TITLE
Use sAMAccountName as X.509 CN in shadowCredentials

### DIFF
--- a/bloodyAD/cli_modules/add.py
+++ b/bloodyAD/cli_modules/add.py
@@ -573,7 +573,7 @@ async def shadowCredentials(conn: ConnectionHandler, target: str, path: str = "C
         )
 
     LOG.debug("Generating KeyCredential")
-    keyCredential = KeyCredential.generate_self_signed_certificate(target_dn)
+    keyCredential = KeyCredential.generate_self_signed_certificate(target_sAMAccountName)
     
     LOG.info(
         "KeyCredential generated with following sha256 of RSA key: %s"


### PR DESCRIPTION
Big fan of bloodyAD, thanks for building and maintaining it!

## What

- In `shadowCredentials`, pass `target_sAMAccountName` instead of `target_dn` to `KeyCredential.generate_self_signed_certificate`.

```diff
-    keyCredential = KeyCredential.generate_self_signed_certificate(target_dn)
+    keyCredential = KeyCredential.generate_self_signed_certificate(target_sAMAccountName)
```

## Why

RFC 5280 (Appendix A) defines `ub-common-name = 64`, capping the X.509 Common Name at 64 characters. The Python `cryptography` library enforces this strictly. Any account whose Distinguished Name exceeds 64 characters causes an unhandled crash:

```
File ".../badldap/commons/keycredential.py", line 90, in generate_self_signed_certificate
    x509.NameAttribute(NameOID.COMMON_NAME, subject),
ValueError: Attribute's length must be >= 1 and <= 64, but it was 65
```

The full DN is not meaningful as a certificate subject anyway — the cert is a short-lived PKINIT credential, not a TLS identity. Both [pywhisker](https://github.com/ShutdownRepo/pywhisker) and [certipy](https://github.com/ly4k/Certipy) use only the `sAMAccountName`:

```python
# pywhisker/pywhisker.py
certificate = X509Certificate2(subject=self.target_samname, ...)

# certipy/commands/shadow.py
sam_account_name = self._get_sam_account_name(user)
key, cert, key_credential, device_id = self.generate_key_credential(sam_account_name)
```

`target_sAMAccountName` is already fetched in the same LDAP query (line 567) so no extra round-trip is needed.

Ran into this in a recent HTB machine.

## Repro

Run `add shadowCredentials` against any account whose DN is longer than 64 characters:

```
$ bloodyAD -H dc.example.htb -d example.htb -u attacker -p 'Password1!' add shadowCredentials someuser
Traceback (most recent call last):
  ...
ValueError: Attribute's length must be >= 1 and <= 64, but it was 65
```

After this fix:

```
[+] KeyCredential generated with following sha256 of RSA key: ...
[+] TGT stored in ccache file someuser_xx.ccache
NT: ...
```
