### PR TITLE
Fix SyntaxWarning: move return out of finally block

### DIFF
--- a/bloodyAD/network/ldap.py
+++ b/bloodyAD/network/ldap.py
@@ -712,7 +712,7 @@ class Ldap(MSLDAPClient):
         finally:
             if newconn != conn and newconn._ldap:
                 await newconn._ldap.close()
-            return search_results
+        return search_results
 
     async def searchInPartition(
         self,
@@ -767,6 +767,6 @@ class Ldap(MSLDAPClient):
         finally:
             if newconn != conn and newconn._ldap:
                 await newconn._ldap.close()
-            return search_result
+        return search_result
 
 


### PR DESCRIPTION
This PR addresses the SyntaxWarning: 'return' in a 'finally' block in ldap.py. This warning occurs in newer Python versions because returning inside a finally block can override exceptions and the original return value from the try block.